### PR TITLE
Update mo2.html

### DIFF
--- a/mo2.html
+++ b/mo2.html
@@ -277,7 +277,7 @@
                         <li>Search for <strong>Mod Organizer 2</strong>, or whatever you named it during setup. Click on it.</li>
                         <li>Click on the <img class="mo2-icon" src="./img/Others/Steam Settings.webp" alt="Steam settings"> icon,  which can be found third from the right in the <strong>Game Details</strong> pane.</li>
                         <li>Paste the following into the box marked <strong>Launch Options</strong>
-                            <textarea readonly="" style="height: 3.3em" onclick="this.focus();this.select()">STEAM_COMPAT_DATA_PATH="/home/ky/.local/share/Steam/steamapps/compatdata/22380" %command%"</textarea></li>
+                            <textarea readonly="" style="height: 3.3em" onclick="this.focus();this.select()">STEAM_COMPAT_DATA_PATH="/home/deck/.local/share/Steam/steamapps/compatdata/22380" %command%</textarea></li>
                         <li>Click <strong>Properties</strong> from the drop down.</li>
                         <li>Click <strong>Compatibility</strong></li>
                         <li>Click the checkbox marked <strong>Force the use of a specific Steam Play compatibility


### PR DESCRIPTION
Remove trailing double quote in text box for Launch Options string for MO2. Leaving it in will cause a crash on deck

Also update path to be /home/deck... for the deck default user rather than "ky"